### PR TITLE
Add an example Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1
+FROM devkitpro/devkitarm
+COPY . .
+RUN wget https://github.com/WebAssembly/wabt/releases/download/1.0.30/wabt-1.0.30-ubuntu.tar.gz && \
+    tar xzf wabt-1.0.30-ubuntu.tar.gz
+ENV PATH=/wabt-1.0.30/bin:$PATH
+WORKDIR /

--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ Troubleshooting:
     * Run `./build.sh -f wasm2c file.wasm ...`
 
 ## Building in a local docker container
+  To build for `gba`, `nds`, and `3ds` platforms with docker:
+
     $ docker build -t wasm4-aot-image .
     $ docker run -v $PWD:/pwd_dir --rm wasm4-aot-image ./build.sh -f wasm2c /pwd_dir/cart.wasm [platform] /pwd_dir/[output_file]
+
+  Other platforms: TBD
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ software (like WASM-4 games) to low-end platforms, like microcontrollers or "ret
 
 ## Building
 
-    $ ./build.sh file.wasm platform [output_file]
+    $ ./build.sh file.wasm [platform] [output_file]
 
 Supported platforms:
 
@@ -30,6 +30,10 @@ Troubleshooting:
   * `w2c2: unsupported opcode unknown` - use the wasm2c frontend instead:
     * Install wabt (**1.0.30 only**), add to PATH
     * Run `./build.sh -f wasm2c file.wasm ...`
+
+## Building in a local docker container
+    $ docker build -t wasm4-aot-image .
+    $ docker run -v $PWD:/pwd_dir --rm wasm4-aot-image ./build.sh -f wasm2c /pwd_dir/cart.wasm [platform] /pwd_dir/[output_file]
 
 ## License
 


### PR DESCRIPTION
Found that devkit had pre-existing docker images which makes it a bit easier to setup and play with wasm4-aot.

I've been using this simple Dockerfile locally and thought it might be useful to share.